### PR TITLE
Removed Debug Logging and Fixed Issue that Prevented QueryFollowerById from working

### DIFF
--- a/client.go
+++ b/client.go
@@ -71,7 +71,7 @@ func (c *Client) QueryFollowerIDs(count int) (FollowerIDs, []byte, error) {
 }
 
 func (c *Client) QueryFollowerById(id int) (UserDetail, []byte, error) {
-	requesURL := fmt.Sprintf("%s?user_id=%d&screen_name=twitterdev", API_FOLLOWER_INFO, id)
+	requesURL := fmt.Sprintf("%s?user_id=%d", API_FOLLOWER_INFO, id)
 	data, err := c.BasicQuery(requesURL)
 	var ret UserDetail
 	err = json.Unmarshal(data, &ret)

--- a/desktop_client.go
+++ b/desktop_client.go
@@ -19,7 +19,8 @@ func NewDesktopClient(consumerKey, consumerSecret string) *DesktopClient {
 		},
 	)
 	//Enable debug info
-	newDesktop.OAuthConsumer.Debug(true)
+	newDesktop.OAuthConsumer.Debug(false)
+
 	return newDesktop
 }
 

--- a/server_client.go
+++ b/server_client.go
@@ -1,7 +1,6 @@
 package twitter
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/mrjones/oauth"
@@ -23,10 +22,9 @@ func NewServerClient(consumerKey, consumerSecret string) *ServerClient {
 	)
 
 	//Enable debug info
-	newServer.OAuthConsumer.Debug(true)
+	newServer.OAuthConsumer.Debug(false)
 
 	// newServer.Client = *newClient
-	fmt.Println("[server] init server")
 	newServer.OAuthTokens = make(map[string]*oauth.RequestToken)
 	return newServer
 }
@@ -38,10 +36,8 @@ type ServerClient struct {
 }
 
 func (s *ServerClient) GetAuthURL(tokenUrl string) string {
-	fmt.Println("[server] tokenurl=", tokenUrl)
-	fmt.Printf("[server] consumer=%v \n", s.OAuthConsumer)
 	token, requestUrl, err := s.OAuthConsumer.GetRequestTokenAndUrl(tokenUrl)
-	fmt.Println("[server] token=", token, " requestUrl=", requestUrl, " err=", err)
+
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
- I removed debug logging from this, as it isn't necessary and clutters the logs on production apps
- I fixed the problem on QueryFollowerById that prevented twitter_dev from always getting returned instead of the user with the id you requested.